### PR TITLE
Add getHttpClient() to get client and call the API directly

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -101,6 +101,11 @@ class Client
         $this->httpClient->setHttpClient($client);
     }
 
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
     public function setMock($mock)
     {
         $this->httpClient = $mock;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -88,6 +88,13 @@ class ClientTest extends TestCase
         ]);
     }
 
+    public function testGetHttpClient()
+    {
+        $client = new Client();
+        $client->setMock($this->createMockHttpClient('get', '/me'));
+        $client->getHttpClient()->get('/me');
+    }
+
     private function createMockHttpClient($method, $path, $res = null)
     {
         $mock = $this->getMockBuilder(HttpClient::class)


### PR DESCRIPTION
Now this library need to implement a method for the endpoint.
But I want to call api like this.
```php
$client->getHttpClient()->get('/example');
```

And we can call any endpoint without implementation of method to call api.